### PR TITLE
V2

### DIFF
--- a/td-models/api.yml
+++ b/td-models/api.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   description: Model Engine API for Causemos.
-  version: "May 2021"
+  version: "Sep 2021"
   title: Causemos Modeling Engine API.
 paths:
   # Create model
@@ -20,9 +20,9 @@ paths:
             - A set of INDRA statements (subject-object relationships between concepts; could be represented by just a weighted directed adjacency matrix),
             - A set of indicator time-series data, each mapped to a concept.
 
-          Aggregation:
-            - func in conceptIndicators specifies the aggregation function to be applied on the indicator data to calculate the initial value of each concept. 
-            - Allowed values: {"min", "max", "first", "last", "median"}, where the default value is "last".
+              # Aggregation:
+              #   - func in conceptIndicators specifies the aggregation function to be applied on the indicator data to calculate the initial value of each concept. 
+              #   - Allowed values: {"min", "max", "first", "last", "median"}, where the default value is "last".
         
           Y-Scaling:
             - DySE is a discrete model; indicator data must be converted to positive integers within a range of discrete levels. 
@@ -210,53 +210,59 @@ components:
         id:
           type: string
           description: A Causemos model UUID
-        statements:
+        nodes: 
           type: array
-          description: Causemos INDRA statement
+          description: Nodes and their parameterizations
           items:
             type: object
-        conceptIndicators:
-          type: object
-          description: Node parameters
-          properties:
-            <conceptName>:
-              type: object
-              description: Concept node name
-              properties:
-                name:
-                  type: string
-                func:
-                  type: string
-                numLevels:
-                  type: number
-                values:
-                  allOf:
-                    - $ref: "#/components/schemas/TimeSeries"
-                resolution:
-                  type: string
-                  description: Describes resolution of values, e.g. month, year
-                period:
-                  type: number
-                  description: Indicates seasonality period. If period=1 then there is no seasonality.
+            properties:
+              concept:
+                type: string
+              indicator:
+                type: string
+              values:
+                allOf:
+                  - $ref: "#/components/schemas/TimeSeries"
+              numLevels: 
+                type: number
+                description: Number of discrete leveles (DySE)
+              resolution:
+                type: string
+                description: Describes resolution of values, e.g. month, year
+              period:
+                type: number
+                description: Indicates seasonality period. If period=1 then there is no seasonality.
+        edges:
+          type: array
+          items:
+            type: object
+            properties:
+              source:
+                type: string
+                description: source concept
+              target:
+                type: string
+                description: target concept
+              statements:
+                type: array
+                items:
+                  type: object
     ModelCreationResponse:
       type: object
       properties:
         status:
           type: string
-        conceptIndicators:
-          type: object
-          properties:
-            <conceptName>:
-              type: object
-              properties:
-                initialValue:
-                  type: number
-                scalingFactor:
-                  type: number
-                  description: optional, provided if engine supports y-scaling
-                scalingBias:
-                  type: number
-                  description: optional, provided if engine supports y-scaling
+        nodes:
+          type: array
+          items:
+            concept:
+              type: string
+            scalingFactor:
+              type: number
+              description: optional, provided if engine supports y-scaling
+            scalingBias:
+              type: number
+              description: optional, provided if engine supports y-scaling
         relations:
           type: array
           items:

--- a/td-models/api.yml
+++ b/td-models/api.yml
@@ -308,6 +308,9 @@ components:
               target:
                 type: string
                 description: target concept
+              polarity:
+                type: number
+                description: edge polarity in Causemos. 1=same, -1=opposite, unknown/ambiguous otherwise
               statements:
                 type: array
                 items:

--- a/td-models/api.yml
+++ b/td-models/api.yml
@@ -219,7 +219,7 @@ components:
             - $ref: "#/components/schemas/TimeSeries"
         numLevels: 
           type: number
-          description: Number of discrete leveles (DySE)
+          description: Number of discrete levels (DySE)
         resolution:
           type: string
           description: Describes resolution of values, e.g. month, year

--- a/td-models/api.yml
+++ b/td-models/api.yml
@@ -147,7 +147,7 @@ paths:
                   - $ref: "#/components/schemas/ProjectionResponse"
                   - $ref: "#/components/schemas/SensitivityAnalysisResponse"
 
-  # Update model
+  # Update model nodes
   /models/{modelId}/edit-nodes:
     parameters:
       - $ref: "#/components/parameters/modelId"
@@ -166,24 +166,24 @@ paths:
           description: OK
 
   # Update model
-  /models/{modelId}/edit-edges:
-    parameters:
-      - $ref: "#/components/parameters/modelId"
-    post:
-      summary: Edit edge weight values
-      requestBody:
-        content:
-          application/json:
-            schema:
-              oneOf:
-                - $ref: "#/components/schemas/EditEdgesRequest"
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/EditEdgesResponse"
+  # /models/{modelId}/edit-edges:
+  #   parameters:
+  #     - $ref: "#/components/parameters/modelId"
+  #   post:
+  #     summary: Edit edge weight values
+  #     requestBody:
+  #       content:
+  #         application/json:
+  #           schema:
+  #             oneOf:
+  #               - $ref: "#/components/schemas/EditEdgesRequest"
+  #     responses:
+  #       "200":
+  #         description: OK
+  #         content:
+  #           application/json:
+  #             schema:
+  #               $ref: "#/components/schemas/EditEdgesResponse"
 
         
 components:
@@ -339,6 +339,12 @@ components:
               polarity:
                 type: number
                 description: edge polarity in Causemos. 1=same, -1=opposite, unknown/ambiguous otherwise
+              weights:
+                type: array
+                description: denotes overriding weights analyts want to impose, for DySE this will be [level, trend], for Delphi this will be [weight]
+                items:
+                  description: between [0, 1]
+                  type: number
               statements:
                 type: array
                 items:
@@ -374,7 +380,9 @@ components:
                 type: string
               weights:
                 type: array
+                description: denote inferred edge weights from the engines. e.g. for DySE this will be [level, trend], for Delphy this will be [weight]
                 items:
+                  description: between [0, 1]
                   type: number
 
     ModelExperimentCreationRequest:

--- a/td-models/api.yml
+++ b/td-models/api.yml
@@ -224,12 +224,54 @@ components:
       properties:
         subj:
           type: object
+          properties:
+            concept:
+              type: string
+            factor:
+              type: string
+            adjectives:
+              type: array
+              items:
+                type: string
+            polarity:
+              type: number
         obj:
           type: object
+          properties:
+            concept:
+              type: string
+            factor:
+              type: string
+            adjectives:
+              type: array
+              items:
+                type: string
+            polarity:
+              type: number
         evidence:
           type: array
           items:
             type: object
+            properties:
+              document_context:
+                type: object
+                description: document provenance for the evidence
+              evidence_context:
+                type: object
+                description: evidence level extraction data
+                properties:
+                  subj_polarity:
+                    type: number
+                  subj_adjectives:
+                    type: array
+                    items:
+                      type: string
+                  obj_polarity:
+                    type: number
+                  obj_adjectives:
+                    type: array
+                    items:
+                      type: string
 
     # Basic reusable timeseries
     TimeSeries:
@@ -269,7 +311,8 @@ components:
               statements:
                 type: array
                 items:
-                  type: object
+                  allOf:
+                    - $ref: "#/components/schemas/Statement"
 
     ModelCreationResponse:
       type: object

--- a/td-models/api.yml
+++ b/td-models/api.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   description: Model Engine API for Causemos.
-  version: "Sep 2021"
+  version: "Dec 2021"
   title: Causemos Modeling Engine API.
 paths:
   # Create model
@@ -147,7 +147,7 @@ paths:
                   - $ref: "#/components/schemas/ProjectionResponse"
                   - $ref: "#/components/schemas/SensitivityAnalysisResponse"
 
-  # Update model nodes
+  # Update model
   /models/{modelId}/edit-nodes:
     parameters:
       - $ref: "#/components/parameters/modelId"
@@ -166,24 +166,24 @@ paths:
           description: OK
 
   # Update model
-  # /models/{modelId}/edit-edges:
-  #   parameters:
-  #     - $ref: "#/components/parameters/modelId"
-  #   post:
-  #     summary: Edit edge weight values
-  #     requestBody:
-  #       content:
-  #         application/json:
-  #           schema:
-  #             oneOf:
-  #               - $ref: "#/components/schemas/EditEdgesRequest"
-  #     responses:
-  #       "200":
-  #         description: OK
-  #         content:
-  #           application/json:
-  #             schema:
-  #               $ref: "#/components/schemas/EditEdgesResponse"
+  /models/{modelId}/edit-edges:
+    parameters:
+      - $ref: "#/components/parameters/modelId"
+    post:
+      summary: Edit edge weight values
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+                - $ref: "#/components/schemas/EditEdgesRequest"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EditEdgesResponse"
 
         
 components:
@@ -341,7 +341,7 @@ components:
                 description: edge polarity in Causemos. 1=same, -1=opposite, unknown/ambiguous otherwise
               weights:
                 type: array
-                description: denotes overriding weights analyts want to impose, for DySE this will be [level, trend], for Delphi this will be [weight]
+                description: Optional, denotes overriding weights analyts want to impose, for DySE this will be [level, trend], for Delphi this will be [weight]. If omitted engines should derive their own weights.
                 items:
                   description: between [0, 1]
                   type: number
@@ -380,7 +380,7 @@ components:
                 type: string
               weights:
                 type: array
-                description: denote inferred edge weights from the engines. e.g. for DySE this will be [level, trend], for Delphy this will be [weight]
+                description: denote inferred edge weights from the engines. e.g. for DySE this will be [level, trend], for Delphi this will be [weight]
                 items:
                   description: between [0, 1]
                   type: number

--- a/td-models/api.yml
+++ b/td-models/api.yml
@@ -20,10 +20,6 @@ paths:
             - A set of INDRA statements (subject-object relationships between concepts; could be represented by just a weighted directed adjacency matrix),
             - A set of indicator time-series data, each mapped to a concept.
 
-              # Aggregation:
-              #   - func in conceptIndicators specifies the aggregation function to be applied on the indicator data to calculate the initial value of each concept. 
-              #   - Allowed values: {"min", "max", "first", "last", "median"}, where the default value is "last".
-        
           Y-Scaling:
             - DySE is a discrete model; indicator data must be converted to positive integers within a range of discrete levels. 
             - The number of levels is defined by numLevels in nodes and should be an integer of the form: 
@@ -259,31 +255,6 @@ components:
           items:
             oneOf:
               - $ref: "#/components/schemas/NodeParameter"
-
-            # type: object
-            # properties:
-            #   concept:
-            #     type: string
-            #   indicator:
-            #     type: string
-            #   values:
-            #     allOf:
-            #       - $ref: "#/components/schemas/TimeSeries"
-            #   numLevels: 
-            #     type: number
-            #     description: Number of discrete leveles (DySE)
-            #   resolution:
-            #     type: string
-            #     description: Describes resolution of values, e.g. month, year
-            #   period:
-            #     type: number
-            #     description: Indicates seasonality period. If period=1 then there is no seasonality.
-            #   minValue: 
-            #     type: number
-            #     description: absolute mininum the value can go
-            #   maxValue: 
-            #     type: number
-            #     description: absolute maximum the value can go
         edges:
           type: array
           items:
@@ -299,6 +270,7 @@ components:
                 type: array
                 items:
                   type: object
+
     ModelCreationResponse:
       type: object
       properties:

--- a/td-models/api.yml
+++ b/td-models/api.yml
@@ -26,7 +26,7 @@ paths:
         
           Y-Scaling:
             - DySE is a discrete model; indicator data must be converted to positive integers within a range of discrete levels. 
-            - The number of levels is defined by numLevels in conceptIndicators and should be an integer of the form: 
+            - The number of levels is defined by numLevels in nodes and should be an integer of the form: 
               - numLevels = 6 * n + 1 = 7, 13, 19, ... 
             - For each concept, calculate:
               - scalingFactor = (maxValue - minValue) / ((numLevels - 1.0) / 3.0)
@@ -137,16 +137,19 @@ paths:
                   - $ref: "#/components/schemas/SensitivityAnalysisResponse"
 
   # Update model
-  /models/{modelId}/edit-indicators:
+  /models/{modelId}/edit-nodes:
     parameters:
       - $ref: "#/components/parameters/modelId"
     post:
-      summary: Update indicator specification for a set of nodes
+      summary: Update node parameterization for a set of nodes
       requestBody:
         content:
           application/json:
             schema:
-              type: string
+              type: array
+              items:
+                oneOf:
+                  - $ref: "#/components/schemas/NodeParameter"
       responses:
         "200":
           description: OK
@@ -192,6 +195,46 @@ components:
         format: uuid
 
   schemas:
+    # Node parameterization
+    NodeParameter:
+      type: object
+      properties:
+        concept:
+          type: string
+        indicator:
+          type: string
+        values:
+          allOf:
+            - $ref: "#/components/schemas/TimeSeries"
+        numLevels: 
+          type: number
+          description: Number of discrete leveles (DySE)
+        resolution:
+          type: string
+          description: Describes resolution of values, e.g. month, year
+        period:
+          type: number
+          description: Indicates seasonality period. If period=1 then there is no seasonality.
+        minValue: 
+          type: number
+          description: absolute mininum the value can go
+        maxValue: 
+          type: number
+          description: absolute maximum the value can go
+
+    # General statement structure
+    Statement:
+      type: object
+      properties:
+        subj:
+          type: object
+        obj:
+          type: object
+        evidence:
+          type: array
+          items:
+            type: object
+
     # Basic reusable timeseries
     TimeSeries:
       type: array
@@ -214,24 +257,33 @@ components:
           type: array
           description: Nodes and their parameterizations
           items:
-            type: object
-            properties:
-              concept:
-                type: string
-              indicator:
-                type: string
-              values:
-                allOf:
-                  - $ref: "#/components/schemas/TimeSeries"
-              numLevels: 
-                type: number
-                description: Number of discrete leveles (DySE)
-              resolution:
-                type: string
-                description: Describes resolution of values, e.g. month, year
-              period:
-                type: number
-                description: Indicates seasonality period. If period=1 then there is no seasonality.
+            oneOf:
+              - $ref: "#/components/schemas/NodeParameter"
+
+            # type: object
+            # properties:
+            #   concept:
+            #     type: string
+            #   indicator:
+            #     type: string
+            #   values:
+            #     allOf:
+            #       - $ref: "#/components/schemas/TimeSeries"
+            #   numLevels: 
+            #     type: number
+            #     description: Number of discrete leveles (DySE)
+            #   resolution:
+            #     type: string
+            #     description: Describes resolution of values, e.g. month, year
+            #   period:
+            #     type: number
+            #     description: Indicates seasonality period. If period=1 then there is no seasonality.
+            #   minValue: 
+            #     type: number
+            #     description: absolute mininum the value can go
+            #   maxValue: 
+            #     type: number
+            #     description: absolute maximum the value can go
         edges:
           type: array
           items:
@@ -255,15 +307,17 @@ components:
         nodes:
           type: array
           items:
-            concept:
-              type: string
-            scalingFactor:
-              type: number
-              description: optional, provided if engine supports y-scaling
-            scalingBias:
-              type: number
-              description: optional, provided if engine supports y-scaling
-        relations:
+            type: object
+            properties:
+              concept:
+                type: string
+              scalingFactor:
+                type: number
+                description: optional, provided if engine supports y-scaling
+              scalingBias:
+                type: number
+                description: optional, provided if engine supports y-scaling
+        edges:
           type: array
           items:
             type: object
@@ -439,7 +493,7 @@ components:
     EditEdgesRequest:
       type: object
       properties:
-        relations:
+        edges:
           type: array
           items:
             type: object


### PR DESCRIPTION
Propose changing the format to be more graph-like, specifying nodes/edges directly rather than sending a set of statements and let the receiver figure out the graph-structure. This also allows statements themselves to be more flexible as they can participate in multiple relationships.


### create-model
##### Request
- Rename conceptIndictors to nodes, change from object-of-object to array-of-object
- Removed statements section
- Added edges section
##### Response
- Rename conceptIndicators to nodes, change from object-of-object to array-of-object
- Rename relations to edges



### edit-indicators 
#### Request
- Renamed to edit-nodes
- Change payload from object-of-object to array-of-object

