### PR TITLE
Timeseries distribution

### DIFF
--- a/td-models/api.yml
+++ b/td-models/api.yml
@@ -212,6 +212,8 @@ components:
             type: number
           values:
             type: array
+            items:
+              type: number
 
 
     # For create-model

--- a/td-models/api.yml
+++ b/td-models/api.yml
@@ -203,6 +203,17 @@ components:
           value:
             type: number
 
+    TimeSeriesDistribution:
+      type: array
+      items:
+        type: object
+        properties:
+          timestamp:
+            type: number
+          values:
+            type: array
+
+
     # For create-model
     ModelCreationRequest:
       type: object
@@ -374,16 +385,7 @@ components:
                     type: string
                   values:
                     allOf:
-                      - $ref: "#/components/schemas/TimeSeries"
-                  confidenceInterval:
-                    type: object
-                    properties:
-                      upper:
-                        allOf:
-                          - $ref: "#/components/schemas/TimeSeries"
-                      lower:
-                        allOf:
-                          - $ref: "#/components/schemas/TimeSeries"
+                      - $ref: "#/components/schemas/TimeSeriesDistribution"
     
     SensitivityAnalysisResponse:
       allOf:

--- a/td-models/api.yml
+++ b/td-models/api.yml
@@ -69,6 +69,20 @@ paths:
               schema:
                 $ref: "#/components/schemas/ModelCreationResponse"
 
+  /models/training-progress/{modelId}:
+    parameters:
+      - $ref: "#/components/parameters/modelId"
+    get:
+      summary: Returns the model training progress as a percentage
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema: 
+                  type: number
+              example: 0.97
+
   # Experiments
   /models/{modelId}/experiments:
     parameters:
@@ -257,8 +271,6 @@ components:
       properties:
         status:
           type: string
-        progressPercentage:
-          type: number
         conceptIndicators:
           type: object
           properties:

--- a/td-models/api.yml
+++ b/td-models/api.yml
@@ -79,7 +79,8 @@ paths:
         The payload varies deends on the experiment type, which can be one of [PROJECTION, SENSITIVITY]. This should return immediately with a designated experimentId while the actual experiment runs in the background
 
         PROJECTION:
-          - Generate a time-series projection of each indicator with confidence intervals based on the given model, parameters, and constraints.
+          - Generate a timeseries projection of each indicator based on the given model, parameters, and constraints.
+          - Each timestep of the series contains an array of numbers representing the full distribution of projected values.
 
         GOAL_OPTIMIZATION:
           - Perform optimization over the initial values of the model to ensure that the projections achieve given fixed values or "goals".

--- a/td-models/api.yml
+++ b/td-models/api.yml
@@ -257,6 +257,8 @@ components:
       properties:
         status:
           type: string
+        progressPercentage:
+          type: number
         conceptIndicators:
           type: object
           properties:
@@ -373,6 +375,8 @@ components:
         status:
           type: string
           enum: ["Completed", "In Progress"]
+        progressPercentage:
+          type: number
         
     ProjectionResponse:
       allOf:

--- a/td-models/api.yml
+++ b/td-models/api.yml
@@ -69,7 +69,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ModelCreationResponse"
 
-  /models/training-progress/{modelId}:
+  /models/{modelId}/training-progress:
     parameters:
       - $ref: "#/components/parameters/modelId"
     get:


### PR DESCRIPTION
- Add new type: TimeSeriesDistribution. Just like TimeSeries but with an array of numbers at each timestep, instead of just one.
- Remove confidence interval from ProjectionResponse
- Return TimeSeriesDistribution in ProjectionResponse instead of TimeSeries